### PR TITLE
feat: 优化图像预览显示逻辑

### DIFF
--- a/shorinclip
+++ b/shorinclip
@@ -20,7 +20,6 @@ check_kitty_icat() {
   fi
   (
     # 构造查询序列
-    local query_id query_code fence_code expected
     query_id=$RANDOM
     query_code=$(printf "\033_Gi=%d,s=1,v=1,a=q,t=d,f=24;AAAA\033\\" "$query_id")
     expected=$(printf "\033_Gi=%d;OK\033\\" "$query_id")
@@ -28,16 +27,16 @@ check_kitty_icat() {
     fence_code=$(printf "\033[c")
 
     # 设置终端为非规范模式，单字符读取
-    local stty_orig
     stty_orig=$(stty -g)
     trap "stty '$stty_orig'" EXIT
     stty -echo -icanon min 1 time 0
 
     printf "%s%s" "$query_code" "$fence_code" > /dev/tty
 
-    local response=""
+    response=""
     ret=0
     while true; do
+      # -r 取消转义 -N 1 只读一个字符 -t 0.3 超时0.3秒
       IFS= read -r -N 1 -t 0.3 char || {
         [ -z "$char" ] && break
       }


### PR DESCRIPTION
## 图片显示测试结果

| Terminal       | Status | Protocol |                               |
| -------------- | ------ | -------- | ----------------------------- |
| Kitty          | ✅     | kitty    |                               |
| Ghostty        | ✅     | kitty    |                               |
| Konsole        | ✅     | kitty    |                               |
| WezTerm        | ✅     | sixels   | 使用 kitty 协议时无法正常显示 |
| Warp           | ✅     | kitty    |                               |
| Foot           | ✅     | sixels   |                               |
| Rio            | ✅     | sixels   |                               |
| Alacritty      | ⚠️     | symbols  |                               |
| XFCE4 Terminal | ⚠️     | symbols  |                               |
| XTerm          | ⚠️     | symbols  |                               |
| GNOME Console  | ⚠️     | symbols  |                               |
| Kmscon         | ⚠️     | symbols  |                               |

<details>
<summary>截图</summary>

- Kitty

    <figure>
    <img src="https://io.uyani.de/apps/files_sharing/publicpreview/HwndKny6nGaMTGR?file=/kitty.png&fileId=19722&x=2560&y=1440&a=true&etag=32e05e3b4338cd0800d9b2ed9e7d" alt="kitty.png">
    </figure>

- Ghostty

    <figure>
    <img src="https://io.uyani.de/apps/files_sharing/publicpreview/HwndKny6nGaMTGR?file=/ghostty.png&fileId=19722&x=2560&y=1440&a=true&etag=32e05e3b4338cd0800d9b2ed9e7d" alt="ghostty.png">
    </figure>

- Konsole

    <figure>
    <img src="https://io.uyani.de/apps/files_sharing/publicpreview/HwndKny6nGaMTGR?file=/konsole.png&fileId=19722&x=2560&y=1440&a=true&etag=32e05e3b4338cd0800d9b2ed9e7d" alt="konsole.png">
    </figure>

- WezTerm

    <figure>
    <img src="https://io.uyani.de/apps/files_sharing/publicpreview/HwndKny6nGaMTGR?file=/wezterm.png&fileId=19724&x=2560&y=1440&a=true&etag=32e05e3b4338cd0800d9b2ed9e7d" alt="wezterm.png">
    </figure>

- Warp

    <figure>
    <img src="https://io.uyani.de/apps/files_sharing/publicpreview/HwndKny6nGaMTGR?file=/warp.png&fileId=19724&x=2560&y=1440&a=true&etag=32e05e3b4338cd0800d9b2ed9e7d" alt="warp.png">
    </figure>

- Foot

    <figure>
    <img src="https://io.uyani.de/apps/files_sharing/publicpreview/HwndKny6nGaMTGR?file=/foot.png&fileId=19724&x=2560&y=1440&a=true&etag=32e05e3b4338cd0800d9b2ed9e7d" alt="foot.png">
    </figure>

- Alacritty

    <figure>
    <img src="https://io.uyani.de/apps/files_sharing/publicpreview/HwndKny6nGaMTGR?file=/alacritty.png&fileId=19723&x=2560&y=1440&a=true&etag=32e05e3b4338cd0800d9d0b9b2ed9e7d" alt="alacritty.png">
    </figure>

</details>

## 解决的问题

- Konsole 等终端上显示行数大于 Preview 总行数导致错位;
- WezTerm 等终端上无法显示图片;
- Warp 等终端中无法清除之前显示的图片而直接覆盖.

## 其他改进

- 通过[特殊转义序列](https://sw.kovidgoyal.net/kitty/graphics-protocol/#querying-support-and-available-transmission-mediums)查询终端是否支持 kitty 终端图像协议;
- 移除对 kitty 的依赖.
